### PR TITLE
When Script Canvas gem isn't enabled dont try to create SC nodes

### DIFF
--- a/Code/Source/Integration/Render/AtomIntegration/MeshBatchDrawer.cpp
+++ b/Code/Source/Integration/Render/AtomIntegration/MeshBatchDrawer.cpp
@@ -114,7 +114,7 @@ bool	CMeshBatchDrawer::MapBuffers(SRenderContext &ctx, const SRendererBatchDrawP
 {
 	AZ_UNUSED(ctx);
 	const u32									particleCount = drawPass.m_TotalParticleCount;
-	const u32									drawRequestsCount = drawPass.m_DrawRequests.Count();
+	[[maybe_unused]] const u32									drawRequestsCount = drawPass.m_DrawRequests.Count();
 	CRenderManager								*renderManager = m_RenderContext->m_RenderManager;
 	const CParticleBuffers::SViewIndependent	&viewIndependent = GetCurBuffers().m_ViewIndependent;
 
@@ -178,7 +178,7 @@ bool	CMeshBatchDrawer::EmitDrawCall(SRenderContext &ctx, const SRendererBatchDra
 
 	const u32									particleCount = drawPass.m_TotalParticleCount;
 	const SRendererBatchDrawPass_Mesh_CPUBB		*meshDrawPass = static_cast<const SRendererBatchDrawPass_Mesh_CPUBB*>(&drawPass);
-	const u32									drawRequestsCount = drawPass.m_DrawRequests.Count();
+	[[maybe_unused]] const u32					drawRequestsCount = drawPass.m_DrawRequests.Count();
 	const CParticleBuffers::SViewIndependent	&viewIndependent = GetCurBuffers().m_ViewIndependent;
 	const CAtomRendererCache					*rendererCache = static_cast<const CAtomRendererCache*>(toEmit.m_RendererCaches.First().Get());
 

--- a/Code/Source/PopcornFXSystemComponent.cpp
+++ b/Code/Source/PopcornFXSystemComponent.cpp
@@ -93,7 +93,10 @@ namespace PopcornFX {
 
 	void	PopcornFXSystemComponent::Init()
 	{
-		PopcornFXLibrary::InitNodeRegistry(ScriptCanvas::GetNodeRegistry().Get());
+		if (ScriptCanvas::GetNodeRegistry().IsConstructed())
+		{
+			PopcornFXLibrary::InitNodeRegistry(ScriptCanvas::GetNodeRegistry().Get());
+		}
 	}
 
 	void	PopcornFXSystemComponent::Activate()


### PR DESCRIPTION
- Fixes a crash when processing assets when Script Canvas gem isn't enabled alongside with PopcornFX gem.
- Compile warning fixes on VS2022.

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>