### PR TITLE
Added a header-only target: Gem::PopcornFX.API

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -21,6 +21,17 @@ endif()
 add_compile_definitions(PK_O3DE_MAJOR_VERSION=${PK_O3DE_MAJOR_VERSION})
 add_compile_definitions(PK_O3DE_PATCH_VERSION=${PK_O3DE_PATCH_VERSION})
 
+# The PopcornFX.API target declares the common interface that users of this gem can depend on in their targets without requiring linking.
+ly_add_target(
+    NAME PopcornFX.API INTERFACE
+    NAMESPACE Gem
+    FILES_CMAKE
+        popcornfx_api_files.cmake
+    INCLUDE_DIRECTORIES
+        INTERFACE
+            Include
+)
+
 ly_add_target(
     NAME PopcornFX.Static STATIC
     NAMESPACE Gem

--- a/Code/popcornfx_api_files.cmake
+++ b/Code/popcornfx_api_files.cmake
@@ -1,0 +1,8 @@
+#----------------------------------------------------------------------------
+# Copyright Persistant Studios, SARL. All Rights Reserved.
+# https://www.popcornfx.com/terms-and-conditions/
+#----------------------------------------------------------------------------
+
+set(FILES
+    Include/PopcornFX/PopcornFXBus.h
+)


### PR DESCRIPTION
I am proposing a new header-only CMake target that avoids linking PopcornFX code to other gems.
Using `Gem::PopcornFX.API` as a dependency speeds up compilation compared to using Gem::PopcornFX.Static.

(I tested this in a small project.)

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>