### PR TITLE
Fixed AP processing issues of prefabs with PFX components in them

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -131,11 +131,17 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME PopcornFX.Builders GEM_MODULE
         NAMESPACE Gem
+        AUTOUIC
+        AUTOMOC
+        AUTORCC
         FILES_CMAKE
             popcornfx_builder_files.cmake
+            popcornfx_editor_files.cmake # Note: pipeline tools need access to editor components in order to process .prefabs
         COMPILE_DEFINITIONS
             PRIVATE
+                QT_NO_KEYWORDS
                 POPCORNFX_BUILDER
+                POPCORNFX_EDITOR
         INCLUDE_DIRECTORIES
             PRIVATE
                 Source


### PR DESCRIPTION
Before this fix, the AP would report a warning while processing .prefabs with PopcornFX components in them:
```
Prefab Serialization: Unable to resolve provided type: PopcornFXEmitterEditorComponent.
```

The end result was particles working in the Editor viewport but not in the game mode.
With this fix, particles work in the game mode as well.

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>