### PR TITLE
Fix monolithic builds and other errors

### DIFF
--- a/Code/Include/PopcornFX/PopcornFXBus.h
+++ b/Code/Include/PopcornFX/PopcornFXBus.h
@@ -27,7 +27,7 @@ namespace PopcornFX
 #if PK_O3DE_MAJOR_VERSION > 2210
 	static constexpr AZ::Uuid EmitterComponentTypeId = AZ::Uuid("{515957e3-8354-4048-8d6c-98628ef21804}");
 	static constexpr AZ::Uuid EditorEmitterComponentTypeId = AZ::Uuid("{B62ED02E-731B-4ACD-BCA1-78EF92528228}");
-	static constexpr AZ::Uuid AssetTypeId = AZ::Uuid("{B62ED02E-731B-4ACD-BCA1-78EF92528228}");
+	static constexpr AZ::Uuid AssetTypeId = AZ::Uuid("{45047C35-64F7-43BA-B463-000081B587C3}");
 #else
 	static const AZ::Uuid EmitterComponentTypeId = AZ::Uuid("{515957e3-8354-4048-8d6c-98628ef21804}");
 	static const AZ::Uuid EditorEmitterComponentTypeId = AZ::Uuid("{B62ED02E-731B-4ACD-BCA1-78EF92528228}");

--- a/Code/Source/Integration/Preloader/PopcornFXRendererLoader.cpp
+++ b/Code/Source/Integration/Preloader/PopcornFXRendererLoader.cpp
@@ -782,10 +782,19 @@ bool	PopcornFXRendererLoader::_AddTextureToLoad(	const char *texturePath,
 		return false;
 
 	//Load Texture
-	AzFramework::AssetSystem::AssetStatus	status = AzFramework::AssetSystem::AssetStatus_Unknown;
-	EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, texturePath);
-	if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
-		CLog::Log(PK_ERROR, "Could not compile image at '%s'", texturePath);
+	bool apConnected = false;
+	AzFramework::AssetSystemRequestBus::BroadcastResult(
+		apConnected, &AzFramework::AssetSystemRequestBus::Events::ConnectedWithAssetProcessor);
+	if (apConnected)
+	{
+		// If the Asset Processor is available, make sure the assets are compiled.
+		AzFramework::AssetSystem::AssetStatus status = AzFramework::AssetSystem::AssetStatus_Unknown;
+		EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, texturePath);
+		if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+		{
+			CLog::Log(PK_ERROR, "Could not compile image at '%s'", texturePath);
+		}
+	}
 	AZ::Data::AssetId	streamingImageAssetId;
 	EBUS_EVENT_RESULT(streamingImageAssetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, texturePath, azrtti_typeid<AZ::RPI::StreamingImageAsset>(), false);
 	if (!streamingImageAssetId.IsValid())
@@ -841,13 +850,20 @@ bool	PopcornFXRendererLoader::_AddGeometryToLoad(const char *geometryPath,
 {
 	AZ::Data::AssetId	assetId;
 
-	AzFramework::AssetSystem::AssetStatus	status = AzFramework::AssetSystem::AssetStatus_Unknown;
-	EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, geometryPath);
-	if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+	bool apConnected = false;
+	AzFramework::AssetSystemRequestBus::BroadcastResult(
+		apConnected, &AzFramework::AssetSystemRequestBus::Events::ConnectedWithAssetProcessor);
+	if (apConnected)
 	{
-		CLog::Log(PK_ERROR, "Could not compile model at '%s'", geometryPath);
-		return false;
+		// If the Asset Processor is available, make sure the assets are compiled.
+		AzFramework::AssetSystem::AssetStatus	status = AzFramework::AssetSystem::AssetStatus_Unknown;
+		EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, geometryPath);
+		if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+		{
+			CLog::Log(PK_ERROR, "Could not compile model at '%s'", geometryPath);
+		}
 	}
+
 	EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, geometryPath, azrtti_typeid<AZ::RPI::Model>(), false);
 	if (!assetId.IsValid())
 	{
@@ -872,10 +888,19 @@ bool	PopcornFXRendererLoader::_AddGeometryToLoad(const char *geometryPath,
 
 AZ::Data::AssetId	PopcornFXRendererLoader::_LoadTexture(const CString &path)
 {
-	AzFramework::AssetSystem::AssetStatus	status = AzFramework::AssetSystem::AssetStatus_Unknown;
-	EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, path.Data());
-	if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
-		CLog::Log(PK_ERROR, "Could not compile image at '%s'", path.Data());
+	bool apConnected = false;
+	AzFramework::AssetSystemRequestBus::BroadcastResult(
+		apConnected, &AzFramework::AssetSystemRequestBus::Events::ConnectedWithAssetProcessor);
+	if (apConnected)
+	{
+		// If the Asset Processor is available, make sure the assets are compiled.
+		AzFramework::AssetSystem::AssetStatus	status = AzFramework::AssetSystem::AssetStatus_Unknown;
+		EBUS_EVENT_RESULT(status, AzFramework::AssetSystemRequestBus, CompileAssetSync, path.Data());
+		if (status != AzFramework::AssetSystem::AssetStatus_Compiled)
+		{
+			CLog::Log(PK_ERROR, "Could not compile image at '%s'", path.Data());
+		}
+	}
 
 	AZ::Data::AssetId	streamingImageAssetId;
 	EBUS_EVENT_RESULT(streamingImageAssetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, path.Data(), azrtti_typeid<AZ::RPI::StreamingImageAsset>(), false);

--- a/Code/Source/Integration/Render/AtomIntegration/PopcornFXFeatureProcessor.h
+++ b/Code/Source/Integration/Render/AtomIntegration/PopcornFXFeatureProcessor.h
@@ -25,6 +25,7 @@ class CPopcornFXFeatureProcessor : public CPopcornFXFeatureProcessorInterface
 {
 public:
 	AZ_RTTI(CPopcornFXFeatureProcessor, "{D86216E4-92A8-43BE-123F-883489C75BA1}", CPopcornFXFeatureProcessorInterface);
+	AZ_CLASS_ALLOCATOR(CPopcornFXFeatureProcessor, AZ::SystemAllocator);
 
 	CPopcornFXFeatureProcessor();
 	virtual ~CPopcornFXFeatureProcessor() = default;


### PR DESCRIPTION
This fixes 3 separate problems:
1) The asset ID recently moved to a header file had a cut-and-paste error causing it to have the same ID as the EditorEmitterComponentTypeId. It has been restored to the correct ID.
2) The PopcornFXFeatureProcessor class was missing an allocator declaration, causing an assert at startup due to a size mismatch.
3) The PopcornFXRendererLoader didn't work correctly with monolithic builds that don't use the Asset Processor. It still tried to compile assets, which caused warnings for images but still worked, but failed for geometry because the asset would not get loaded if it couldn't compile. This corrects the geometry failure and also removes the compile asset failure warnings in the cases that the Asset Processor isn't connected.