### PR TITLE
Non-build build fix

### DIFF
--- a/Code/Source/PopcornFXModule.cpp
+++ b/Code/Source/PopcornFXModule.cpp
@@ -17,7 +17,8 @@
 #include "Components/Helpers/PopcornFXHelperLoopEmitterEditorComponent.h"
 #include "Components/Helpers/PopcornFXHelperProfilerEditorComponent.h"
 #include "PopcornFXPreviewersSystemComponent.h"
-#elif defined(POPCORNFX_BUILDER)
+#endif
+#if defined(POPCORNFX_BUILDER)
 #include "Asset/PopcornFXAssetBuilderComponent.h"
 #endif
 


### PR DESCRIPTION
PopcornFX.Builders defines both 
- POPCORNFX_BUILDER
- POPCORNFX_EDITOR

Thus, changing the logic to support both in the same compilation object.

Tested with -DLY_UNITY_BUILD=OFF