### PR TITLE
Fix DX12 driver crash related to BillboardDistortion shader 

### DIFF
--- a/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
+++ b/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
@@ -77,15 +77,18 @@ PixelOutput BillboardFS(VertexOutput input)
     PixelOutput output;
 
     float2  texCoords0 = input.m_texCoords0;
-    float2  texCoords1 = input.m_texCoords1;
-
     float4 distortionColor = input.m_distortionColor;
     float4 textureColor = float4(0, 0, 0, 0);
 
     if (HasOneRendererFlags(Has_AnimBlend))
+    {
+        float2  texCoords1 = input.m_texCoords1;
         textureColor = GetDistortionColor(texCoords0, texCoords1, input.m_texFrameLerp);
+    }
     else
+    {
         textureColor = GetDistortionColor(texCoords0);
+    }
 
     distortionColor *= textureColor;
 

--- a/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
+++ b/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
@@ -47,6 +47,11 @@ VertexOutput BillboardVS(VertexInput input)
     float2  vtxUV1;
     float   vtxTexFrameLerp;
 
+    //Update all UV streams or the dx12 driver complains
+    output.m_texCoords0 = float2(0.0f,0.0f);
+    output.m_texCoords1 = float2(0.0f,0.0f);
+    output.m_texFrameLerp = 0.0f;
+    
     ComputeBillboardVertex(particleIdx, input.m_uv, vtxWorldPos, vtxUV0, vtxUV1, vtxTexFrameLerp);
 
     output.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(vtxWorldPos, 1.0f));


### PR DESCRIPTION
This specific shader yielded this dx12 error. Fixing it by initializing the UV streams at start.

```

D3D12 ERROR: ID3D12Device::CreateGraphicsPipelineState: Vertex Shader - Pixel Shader linkage error: Stages are incompatible with each other. Semantic 'UV' is always read by the downstream shader, but never written by the upstream shader (even though the semantic is present in its output signature). [ STATE_CREATION ERROR #664: CREATEGRAPHICSPIPELINESTATE_SHADER_LINKAGE_NEVERWRITTEN_ALWAYSREADS]
D3D12: **BREAK** enabled for the previous message, which was: [ ERROR STATE_CREATION #664: CREATEGRAPHICSPIPELINESTATE_SHADER_LINKAGE_NEVERWRITTEN_ALWAYSREADS ]
Exception thrown at 0x00007FFDBFA0CD29 (KernelBase.dll) in Editor.exe: 0x0000087A (parameters: 0x0000000000000001, 0x0000004A68194C20, 0x0000004A681969F0).
Unhandled exception at 0x00007FFDBFA0CD29 (KernelBase.dll) in Editor.exe: 0x0000087A (parameters: 0x0000000000000001, 0x0000004A68194C20, 0x0000004A681969F0).
```
