### PR TITLE
Enables PopcornFX for Unified launchers

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -95,6 +95,7 @@ ly_add_target(
 )
 
 ly_create_alias(NAME PopcornFX.Clients NAMESPACE Gem TARGETS Gem::PopcornFX)
+ly_create_alias(NAME PopcornFX.Unified NAMESPACE Gem TARGETS Gem::PopcornFX)
 #ly_create_alias(NAME PopcornFX.Servers NAMESPACE Gem TARGETS Gem::PopcornFX)
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)


### PR DESCRIPTION
For context:
- Unified launchers contain both game and server code
- Game launchers have client code only
- Server launchers can be limited to server logic only
