### PR TITLE
Add buffer alignment to 16 bytes

### DIFF
--- a/Code/Source/Integration/Managers/RenderManager.cpp
+++ b/Code/Source/Integration/Managers/RenderManager.cpp
@@ -179,6 +179,7 @@ AZ::RHI::Ptr<AZ::RHI::Buffer>	CRenderManager::AllocBuffer(AZ::u64 bufferSize, AZ
 	AZ::RHI::Ptr<AZ::RHI::Buffer> outBuffer = AZ::RHI::Factory::Get().CreateBuffer();
 	AZ::RHI::BufferInitRequest bufferRequest;
 	bufferRequest.m_descriptor = AZ::RHI::BufferDescriptor{ binding, alignedBufferSize };
+	bufferRequest.m_descriptor.m_alignment = 0x10;
 	bufferRequest.m_buffer = outBuffer.get();
 	AZ::RHI::ResultCode result = m_BufferPool->InitBuffer(bufferRequest);
 


### PR DESCRIPTION
Mapping a graphics buffers does not guarantee a 16 byte alignment needed for SIMD operations. With the new graphic memory allocator that O3DE will start to use for Vulkan, misaligned address are returned when mapping a buffer. By  adding the specific alignment when creating the buffer, the returned address when mapping should always be aligned to 16 byte.

Fixes #45 