### PR TITLE
Linux monolithic build fixes

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -40,6 +40,8 @@ ly_add_target(
         popcornfx_autogen_files.cmake
         popcornfx_shared_files.cmake
         ../Assets/popcornfx_asset_files.cmake
+    PLATFORM_INCLUDE_FILES
+        ${pal_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}.cmake
     COMPILE_DEFINITIONS
         PUBLIC
             O3DE_USE_PK

--- a/Code/Platform/Linux/platform_linux.cmake
+++ b/Code/Platform/Linux/platform_linux.cmake
@@ -1,0 +1,8 @@
+#----------------------------------------------------------------------------
+# Copyright Persistant Studios, SARL. All Rights Reserved.
+# https://www.popcornfx.com/terms-and-conditions/
+#----------------------------------------------------------------------------
+
+set(LY_BUILD_DEPENDENCIES
+    PRIVATE
+        bfd) # on Ubuntu, this library comes from binutils-dev package

--- a/Code/Platform/Mac/platform_mac.cmake
+++ b/Code/Platform/Mac/platform_mac.cmake
@@ -1,0 +1,4 @@
+#----------------------------------------------------------------------------
+# Copyright Persistant Studios, SARL. All Rights Reserved.
+# https://www.popcornfx.com/terms-and-conditions/
+#----------------------------------------------------------------------------

--- a/Code/Platform/Windows/platform_windows.cmake
+++ b/Code/Platform/Windows/platform_windows.cmake
@@ -1,0 +1,4 @@
+#----------------------------------------------------------------------------
+# Copyright Persistant Studios, SARL. All Rights Reserved.
+# https://www.popcornfx.com/terms-and-conditions/
+#----------------------------------------------------------------------------

--- a/Code/Source/Integration/Render/AtomIntegration/PopcornFXFeatureProcessor.cpp
+++ b/Code/Source/Integration/Render/AtomIntegration/PopcornFXFeatureProcessor.cpp
@@ -215,27 +215,27 @@ const AZ::RHI::DrawPacket	*CPopcornFXFeatureProcessor::BuildDrawPacket(	const SA
 	if (objectSrg != null)
 	{
 		// retrieve probe constant indices
-		AZ::RHI::ShaderInputConstantIndex	modelToWorldConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_modelToWorld"));
+	 	[[maybe_unused]] AZ::RHI::ShaderInputConstantIndex	modelToWorldConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_modelToWorld"));
 		AZ_Error("MeshDataInstance", modelToWorldConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
-		AZ::RHI::ShaderInputConstantIndex	modelToWorldInverseConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_modelToWorldInverse"));
+		[[maybe_unused]] AZ::RHI::ShaderInputConstantIndex	modelToWorldInverseConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_modelToWorldInverse"));
 		AZ_Error("MeshDataInstance", modelToWorldInverseConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
-		AZ::RHI::ShaderInputConstantIndex	outerObbHalfLengthsConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_outerObbHalfLengths"));
+		[[maybe_unused]] AZ::RHI::ShaderInputConstantIndex	outerObbHalfLengthsConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_outerObbHalfLengths"));
 		AZ_Error("MeshDataInstance", outerObbHalfLengthsConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
-		AZ::RHI::ShaderInputConstantIndex	innerObbHalfLengthsConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_innerObbHalfLengths"));
+		[[maybe_unused]] AZ::RHI::ShaderInputConstantIndex	innerObbHalfLengthsConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_innerObbHalfLengths"));
 		AZ_Error("MeshDataInstance", innerObbHalfLengthsConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
 		AZ::RHI::ShaderInputConstantIndex	useReflectionProbeConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_useReflectionProbe"));
 		AZ_Error("MeshDataInstance", useReflectionProbeConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
-		AZ::RHI::ShaderInputConstantIndex	useParallaxCorrectionConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_useParallaxCorrection"));
+		[[maybe_unused]] AZ::RHI::ShaderInputConstantIndex	useParallaxCorrectionConstantIndex = objectSrg->FindShaderInputConstantIndex(AZ::Name("m_reflectionProbeData.m_useParallaxCorrection"));
 		AZ_Error("MeshDataInstance", useParallaxCorrectionConstantIndex.IsValid(), "Failed to find ReflectionProbe constant index");
 
 		// retrieve probe cubemap index
 		AZ::Name	reflectionCubeMapImageName = AZ::Name("m_reflectionProbeCubeMap");
-		AZ::RHI::ShaderInputImageIndex reflectionCubeMapImageIndex = objectSrg->FindShaderInputImageIndex(reflectionCubeMapImageName);
+		[[maybe_unused]] AZ::RHI::ShaderInputImageIndex reflectionCubeMapImageIndex = objectSrg->FindShaderInputImageIndex(reflectionCubeMapImageName);
 		AZ_Error("MeshDataInstance", reflectionCubeMapImageIndex.IsValid(), "Failed to find shader image index [%s]", reflectionCubeMapImageName.GetCStr());
 
 #if PK_O3DE_MAJOR_VERSION == 2111


### PR DESCRIPTION
These fixes are required to fix compilation and linking issues on Linux when building monolitihic game launcher.

For example:
```shell
cmake -S /home/olex/git/o3de -B /home/olex/git/o3de/build/mono -G "Ninja Multi-Config" \
    -DALLOW_SETTINGS_REGISTRY_DEVELOPMENT_OVERRIDES=0 \
    -DLY_MONOLITHIC_GAME=1 \
    -DLY_PROJECTS="/home/olex/git/o3de-multiplayersample" 

cmake --build /home/olex/git/o3de/build/mono \
    --target MultiplayerSample.ServerLauncher MultiplayerSample.GameLauncher --config profile
```

I also had to install binutils-dev packaged on Ubuntu:
```shell
sudo apt-get install binutils-dev
```