### PR TITLE
giving value in GetValueColor a default color to fix warning as error msg

### DIFF
--- a/Code/Source/Components/Attributes/TrackView/PopcornFXTrackViewAttribute.cpp
+++ b/Code/Source/Components/Attributes/TrackView/PopcornFXTrackViewAttribute.cpp
@@ -322,7 +322,7 @@ namespace PopcornFX {
 
 	AZ::Color	PopcornFXTrackViewAttribute::GetValueColor() const
 	{
-		AZ::Color	value;
+		AZ::Color	value = AZ::Colors::HotPink;
 		if (!AttributeValid())
 			return value;
 		PopcornFX::PopcornFXEmitterComponentRequestBus::EventResult(value, m_ParentId, &PopcornFX::PopcornFXEmitterComponentRequests::GetAttributeAsColor, m_AttributeId);


### PR DESCRIPTION
When trying to compile o3de-multiplayersample-assets with O3DEPopcornFXPlugin via CMake, I get the following issues:
```
[INFO] root: C:\workspace\dev\o3de-multiplayersample-assets\Gems\O3DEPopcornFXPlugin\Code\Source\Components\Attributes\TrackView\PopcornFXTrackViewAttribute.cpp(327): error C2220: the following warning is treated as an error [C:\workspace\dev\o3de-multiplayersample\build\windows\External\O3DEPopcornFXPlugin-bbe9e60f\Code\PopcornFX.Static.vcxproj]

[INFO] root: C:\workspace\dev\o3de-multiplayersample-assets\Gems\O3DEPopcornFXPlugin\Code\Source\Components\Attributes\TrackView\PopcornFXTrackViewAttribute.cpp(327): warning C4700: uninitialized local variable 'value' used [C:\workspace\dev\o3de-multiplayersample\build\windows\External\O3DEPopcornFXPlugin-bbe9e60f\Code\PopcornFX.Static.vcxproj]
```
The proposed fix simply initializes the value to AZ::Colors:HotPink. Afterwards, everything compiles normally.