### PR TITLE
Add required default textures

### DIFF
--- a/Assets/PopcornFX_Dependencies.xml
+++ b/Assets/PopcornFX_Dependencies.xml
@@ -37,4 +37,5 @@
     <Dependency path="shaders/depth/billboard/depthpasstransparentminbillboard.azshadervarianttree" optional="true" />
     <Dependency path="shaders/mesh/legacy/mesh_legacy.azshadervarianttree" optional="true" />
     <Dependency path="shaders/mesh/legacy/meshlit_legacy.azshadervarianttree" optional="true" />
+    <Dependency path="library/popcornfxcore/materials/defaulttextures/*" optional="true" />
 </EngineDependencies>


### PR DESCRIPTION
The default textures appear to be required for the render cache feature to work, otherwise particles do not render.

[`AddMaterialToCreate`](https://github.com/PopcornFX/O3DEPopcornFXPlugin/blob/development/Code/Source/Integration/Preloader/PopcornFXRendererLoader.cpp#L38) was silently failing in my testing, which was a release build with debug symbols enabled.

I think these errors should be at least logged because if the RenderCache isn't created, no particles render and it will be very hard for a developer to find how to solve the issue because they can't see what assets are missing.

NOTE: in a release build `AZ_Error` macros do nothing, `AZ_Printf` might.  I didn't try a profile `.pak` build, which may have shown the errors, but am thinking maybe maybe there should be some kind of log printed even in a release build if a required asset is missing that will cause particles to not draw.