### PR TITLE
Change includes for scene/viewsrg.srgi to scene/viewsrg_all.srgi in all shaders

### DIFF
--- a/Assets/shaders/Billboard/Default/Billboard.azsl
+++ b/Assets/shaders/Billboard/Default/Billboard.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
+++ b/Assets/shaders/Billboard/Default/BillboardDistortion.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Billboard/Default/BillboardLit.azsl
+++ b/Assets/shaders/Billboard/Default/BillboardLit.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #define    PK_LIT_SHADER
 

--- a/Assets/shaders/Billboard/Legacy/BillboardLit_Legacy.azsl
+++ b/Assets/shaders/Billboard/Legacy/BillboardLit_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #define    PK_LIT_SHADER
 

--- a/Assets/shaders/Billboard/Legacy/Billboard_Legacy.azsl
+++ b/Assets/shaders/Billboard/Legacy/Billboard_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Common/ComputeBillboardVertex.azsli
+++ b/Assets/shaders/Common/ComputeBillboardVertex.azsli
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "BillboardSrg.azsli"
 

--- a/Assets/shaders/Common/LightingHelper.azsli
+++ b/Assets/shaders/Common/LightingHelper.azsli
@@ -11,8 +11,8 @@
 #include <Atom/Features/PBR/AlphaUtils.azsli>
 #include <Atom/Features/PBR/LightingOptions.azsli>
 
-#include <viewsrg.srgi>
-#include <scenesrg.srgi>
+#include <viewsrg_all.srgi>
+#include <scenesrg_all.srgi>
 
 #include <Atom/RPI/Math.azsli>
 #include <Atom/RPI/TangentSpace.azsli>

--- a/Assets/shaders/Depth/Basic/DepthPass.azsl
+++ b/Assets/shaders/Depth/Basic/DepthPass.azsl
@@ -3,7 +3,7 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 struct VertexInput
 {

--- a/Assets/shaders/Depth/Billboard/DepthPass.azsl
+++ b/Assets/shaders/Depth/Billboard/DepthPass.azsl
@@ -3,7 +3,7 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 // Billboarding shader:
 #define 	PK_DEPTH_ONLY_SHADER

--- a/Assets/shaders/Depth/Billboard/DepthPassBillboard.azsl
+++ b/Assets/shaders/Depth/Billboard/DepthPassBillboard.azsl
@@ -3,7 +3,7 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #define 	PK_DEPTH_ONLY_SHADER
 #include "../../Common/ComputeBillboardVertex.azsli"

--- a/Assets/shaders/Depth/Mesh/DepthPassMesh.azsl
+++ b/Assets/shaders/Depth/Mesh/DepthPassMesh.azsl
@@ -3,7 +3,7 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include    "../../Common/MeshSrg.azsli"
 

--- a/Assets/shaders/Mesh/Default/Mesh.azsl
+++ b/Assets/shaders/Mesh/Default/Mesh.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Mesh/Default/MeshLit.azsl
+++ b/Assets/shaders/Mesh/Default/MeshLit.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #define    PK_LIT_SHADER
 

--- a/Assets/shaders/Mesh/Legacy/MeshLit_Legacy.azsl
+++ b/Assets/shaders/Mesh/Legacy/MeshLit_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #define    PK_LIT_SHADER
 

--- a/Assets/shaders/Mesh/Legacy/Mesh_Legacy.azsl
+++ b/Assets/shaders/Mesh/Legacy/Mesh_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/PostProcess/DistortionPostProcess.azsl
+++ b/Assets/shaders/PostProcess/DistortionPostProcess.azsl
@@ -7,7 +7,7 @@
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/ScreenSpace/ScreenSpaceUtil.azsli>
 
-#include <scenesrg.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {

--- a/Assets/shaders/Ribbon/Default/Ribbon.azsl
+++ b/Assets/shaders/Ribbon/Default/Ribbon.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Ribbon/Default/RibbonDistortion.azsl
+++ b/Assets/shaders/Ribbon/Default/RibbonDistortion.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>

--- a/Assets/shaders/Ribbon/Default/RibbonLit.azsl
+++ b/Assets/shaders/Ribbon/Default/RibbonLit.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include "../../Common/MaterialSrg.azsli"
 #include "../../Common/RibbonSrg.azsli"
 

--- a/Assets/shaders/Ribbon/Legacy/RibbonLit_Legacy.azsl
+++ b/Assets/shaders/Ribbon/Legacy/RibbonLit_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include "../../Common/MaterialSrg.azsli"
 #include "../../Common/RibbonSrg.azsli"
 

--- a/Assets/shaders/Ribbon/Legacy/Ribbon_Legacy.azsl
+++ b/Assets/shaders/Ribbon/Legacy/Ribbon_Legacy.azsl
@@ -3,8 +3,8 @@
 // https://www.popcornfx.com/terms-and-conditions/
 //----------------------------------------------------------------------------
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #include "../../Common/PopcornOptions.azsli"
 #include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>


### PR DESCRIPTION
Necessary follow-up for [PR 18566](https://github.com/o3de/o3de/pull/18566) that introduced the scene/viewsrg_all.srgi in the engine as a wrapper around the project-specific scene/viewsrg.srgi.